### PR TITLE
Add AWS IAM best practices and S3_BUCKET_ACLS_DISABLE.

### DIFF
--- a/docs/en/admin-guide/management-cookbook/app-settings.md
+++ b/docs/en/admin-guide/management-cookbook/app-settings.md
@@ -186,14 +186,62 @@ Settings are required when using Amazon S3 and Google Cloud Storage.
 
 Here are the steps to set up a connection to Amazon S3 (Amazon Simple Storage Service).
 
-#### Get AWS account infomation
+#### Get AWS credentials
+
+<details><summary>When creating a new IAM User (recommended)</summary>
+
+1. Sign in to [AWS Management Console](https://aws.amazon.com/console/).
+2. Navigate to the [IAM User page](https://us-east-1.console.aws.amazon.com/iam/home#/users).
+3. Create a user.
+    - User name: Any
+    - Provide user access to the AWS Management Console: Off
+    - Set permissions: Press "Next" without making any configurations.
+4. Select the user you created.
+5. Security Credentials -> Access keys -> Create access key
+6. Select JSON in the policy editor and add the following:
+
+```json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:PutObjectAcl",
+				"s3:GetObject"
+			],
+			"Resource": [
+				"arn:aws:s3:::*/*"
+			]
+		}
+	]
+}
+```
+
+::: tip
+It is more secure to replace the first * in the Resource with the name of S3 Bucket that you will create later.  
+example:`"arn:aws:s3:::growi-attachment-bucket/*"`
+:::
+
+7. Enter any name for the policy name and create the policy. 
+8. User details -> Security credentials -> Access keys -> Create access key
+9. Select Other and create access key.
+10. Store the Access Key ID and Secret Access Key.
+
+</details>
+
+<details><summary>When use security credentials of logged-in user</summary>
 
 1. Sign in to [AWS Management Console](https://aws.amazon.com/console/) and
  select [My Security Credentials](https://console.aws.amazon.com/iam/home?#/security_credentials)
-from the dropdown that appears when clicking on the account name in the upper right corner of the navigation bar.
+ from the dropdown that appears when clicking on the account name in the upper right corner of the navigation bar.
 2. Expand "Access Key (Access Key ID and Secret Access Key)",
- create and store the Access Key ID and Secret Access Key for the AWS account.
+create and store the Access Key ID and Secret Access Key for the AWS account.
 3. Expand "Account ID" to comfirm the valid user ID.
+
+
+</details>
 
 #### Get or change permitions of Amazon S3 Bucket
 
@@ -203,6 +251,10 @@ from the dropdown that appears when clicking on the account name in the upper ri
 4. Click the edit button of "Block Public Access".
 only uncheck "Block public access" through the New Access Control List (ACL) and save the changes.
 5. If the valid ID of the AWS account that has been added to the "Bucket Owner Permissions" and the "Access Control List" doesn't match step 3 of the procedure "Getting AWS Account Information", add the account with the verified canonical ID to "Access Other AWS Accounts". In this case, please check all types of authority.
+
+::: tip
+When using a private S3 Bucket (with ACLs disabled and all public access blocked), you should set the environment valiable `S3_BUCKET_ACLS_DISABLE=true` when launching growi.
+:::
 
 #### Register Bucket to GROWI
 

--- a/docs/en/admin-guide/management-cookbook/app-settings.md
+++ b/docs/en/admin-guide/management-cookbook/app-settings.md
@@ -235,7 +235,7 @@ example:`"arn:aws:s3:::growi-attachment-bucket/*"`
 
 1. Sign in to [AWS Management Console](https://aws.amazon.com/console/) and
  select [My Security Credentials](https://console.aws.amazon.com/iam/home?#/security_credentials)
- from the dropdown that appears when clicking on the account name in the upper right corner of the navigation bar.
+from the dropdown that appears when clicking on the account name in the upper right corner of the navigation bar.
 2. Expand "Access Key (Access Key ID and Secret Access Key)",
 create and store the Access Key ID and Secret Access Key for the AWS account.
 3. Expand "Account ID" to comfirm the valid user ID.

--- a/docs/en/admin-guide/management-cookbook/app-settings.md
+++ b/docs/en/admin-guide/management-cookbook/app-settings.md
@@ -237,7 +237,7 @@ example:`"arn:aws:s3:::growi-attachment-bucket/*"`
  select [My Security Credentials](https://console.aws.amazon.com/iam/home?#/security_credentials)
 from the dropdown that appears when clicking on the account name in the upper right corner of the navigation bar.
 2. Expand "Access Key (Access Key ID and Secret Access Key)",
-create and store the Access Key ID and Secret Access Key for the AWS account.
+ create and store the Access Key ID and Secret Access Key for the AWS account.
 3. Expand "Account ID" to comfirm the valid user ID.
 
 

--- a/docs/ja/admin-guide/management-cookbook/app-settings.md
+++ b/docs/ja/admin-guide/management-cookbook/app-settings.md
@@ -182,12 +182,57 @@ Amazon S3, Google Cloud Storage を利用する場合はそれぞれ設定が必
 
 Amazon S3(Amazon Simple Storage Service) への接続設定の手順を紹介します。
 
-#### AWS アカウント情報の取得
+#### AWS 認証情報の取得
+
+<details><summary>IAM Userを新規に作成する場合(推奨)</summary>
+
+1. [AWS マネジメントコンソール](https://aws.amazon.com/jp/console/) にサインインします。
+2. IAMの[IAMユーザー](https://us-east-1.console.aws.amazon.com/iam/home#/users)へ移動します。
+3. ユーザーを作成します。
+    - ユーザー名: 任意
+    - AWS マネジメントコンソールへのユーザーアクセスを提供する: オフ
+    - 許可を設定: 何も追加せずに次へ
+4. 作成したユーザーを選択します。
+5. 許可タブ -> 許可を追加 -> インラインポリシーを作成を選択します。
+6. ポリシーエディタのJSONを選択し、以下を追加します。
+
+```json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:PutObjectAcl",
+				"s3:GetObject"
+			],
+			"Resource": [
+				"arn:aws:s3:::*/*"
+			]
+		}
+	]
+}
+```
+
+※ Resouceの１つ目の*は、後に作成するS3 Bucket名を入力するとよりセキュアです。  
+例: `"arn:aws:s3:::growi-attachment-bucket/*"`
+
+7. ポリシー名に任意の名前を入れてポリシーを作成します。
+8. 作成したユーザーの詳細 -> セキュリティ認証情報タブ -> アクセスキー -> アクセスキーを作成を選択します。
+9. その他を選択 -> アクセスキーを作成します。
+10. Access Key ID および Secret Access Key を作成、保管します。
+
+</details>
+
+<details><summary>ログインユーザーの認証情報を利用する場合</summary>
 
 1. [AWS マネジメントコンソール](https://aws.amazon.com/jp/console/) にサインインします。
 2. ナビバー右上のアカウント名をクリックすると表示されるドロップダウンから、[マイセキュリティ資格情報](https://console.aws.amazon.com/iam/home?#/security_credentials) を選択します。
 3. 「アクセスキー(アクセスキー ID とシークレットアクセスキー)」を展開し、AWS アカウントのAccess Key ID および Secret Access Key を作成、保管します。
 4. 「アカウント ID」を展開し、正規ユーザー ID を確認します。
+
+</details>
 
 #### Amazon S3 Bucket 情報の取得、権限変更
 
@@ -197,6 +242,10 @@ Amazon S3(Amazon Simple Storage Service) への接続設定の手順を紹介し
 4. 「ブロックパブリックアクセス」の編集ボタンをクリックします。
 5. 「新しいアクセスコントロールリスト (ACL) を介して許可されたバケットとオブジェクトへのパブリックアクセスをブロックする」のみチェックを外し、変更を保存します。
 6. 「アクセスコントロールリスト」の「バケット所有者のアクセス権」に追加されている AWS アカウントの正規 ID が手順「AWS アカウント情報の取得」の 3. で確認したものと一致していなければ、「他の AWS アカウントのアクセス」に、確認した正規 ID でアカウントを追加します。この時、権限の種類全てにチェックします。
+
+::: tip
+Private S3 Bucket(ACL無効、パブリックアクセスをブロック)を利用する場合、GROWIの起動時に環境変数`S3_BUCKET_ACLS_DISABLE=true`を設定する必要があります。
+:::
 
 #### GROWI に Bucket を登録
 

--- a/docs/ja/admin-guide/management-cookbook/app-settings.md
+++ b/docs/ja/admin-guide/management-cookbook/app-settings.md
@@ -215,8 +215,10 @@ Amazon S3(Amazon Simple Storage Service) への接続設定の手順を紹介し
 }
 ```
 
-※ Resouceの１つ目の*は、後に作成するS3 Bucket名を入力するとよりセキュアです。  
+::: tip
+Resouceの１つ目の*は、後に作成するS3 Bucket名を入力するとよりセキュアです。  
 例: `"arn:aws:s3:::growi-attachment-bucket/*"`
+:::
 
 7. ポリシー名に任意の名前を入れてポリシーを作成します。
 8. 作成したユーザーの詳細 -> セキュリティ認証情報タブ -> アクセスキー -> アクセスキーを作成を選択します。


### PR DESCRIPTION
ref: https://github.com/weseek/growi/pull/8778

- 上記PRで追加する`S3_BUCKET_ACLS_DISABLE`についての記述を追加
- AWS認証情報について、ログインユーザーのCredentialsではなくIAM Userを作成して最低限のポリシーを当てる方法を推奨として追記