### PR TITLE
Fixed startup command

### DIFF
--- a/docs/en/admin-guide/admin-cookbook/launch-with-systemd.md
+++ b/docs/en/admin-guide/admin-cookbook/launch-with-systemd.md
@@ -18,7 +18,7 @@ WorkingDirectory=/opt/growi
 Environment=PORT=3000\
 MONGO_URI=mongodb://localhost:27017/growi\
 ELASTICSEARCH_URI=http://localhost:9200/growi
-ExecStart=/usr/local/bin/yarn dev:server
+ExecStart=/usr/bin/yarn app:server
 
 [Install]
 WantedBy=multi-user.target
@@ -37,7 +37,7 @@ Set environment variables such as `MONGO_URI` and `FILE_UPLOAD`.
 
 #### ExecStart
 
-Set `ExecStart` according to your environment. On CentOS, set it to `/usr/bin/yarn dev:server`.
+Set `ExecStart` according to your environment. Check the yarn path using `which yarn` etc.
 
 ## Run systemctl
 

--- a/docs/ja/admin-guide/admin-cookbook/launch-with-systemd.md
+++ b/docs/ja/admin-guide/admin-cookbook/launch-with-systemd.md
@@ -18,7 +18,7 @@ WorkingDirectory=/opt/growi
 Environment=PORT=3000\
 MONGO_URI=mongodb://localhost:27017/growi\
 ELASTICSEARCH_URI=http://localhost:9200/growi
-ExecStart=/usr/local/bin/yarn dev:server
+ExecStart=/usr/bin/yarn app:server
 
 [Install]
 WantedBy=multi-user.target
@@ -39,7 +39,7 @@ GROWI のディレクトリのある場所を指定します。
 #### ExecStart
 
 起動コマンドを指定します。  
-適宜環境に合わせて設定してください。CentOS では `/usr/bin/yarn dev:server` に変更する必要があります。
+適宜環境に合わせて設定してください。yarn のパスは、`which yarn` などで確認してください。
 
 ## systemctl による操作
 


### PR DESCRIPTION
- 現在、Ubuntu でも yarn のパスは、'/usr/bin/yarn' となることからパスを修正
- それに伴い、CentOS のパスの記述を削除し、yarn のパスは、`which yarn`などで確認するように変更
- 通常のインストール手順では、`dev:server`が `Command "dev:server" not found.` となることから、`app:server` に修正