### PR TITLE
add Attached File Size Limitation about Nginx

### DIFF
--- a/docs/ja/admin-guide/admin-cookbook/attachment.md
+++ b/docs/ja/admin-guide/admin-cookbook/attachment.md
@@ -77,6 +77,8 @@ Azure(Blob) 設定を環境変数によって固定したい場合は、環境�
 - `MAX_FILE_SIZE` : [アップロード可能なファイルのサイズ上限(bytes)]
 - `FILE_UPLOAD_TOTAL_LIMIT` : [アップロードされたファイルの累計サイズ上限(bytes)]
 
+ただし、リバースプロキシに Nginx を利用している場合は、その制限を受けます。1Mバイトを超えるファイルをアップロードする必要がある場合は、[client_max_body_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)ディレクティブを設定してください。
+
 ## 添付ファイル参照方法
 
 v4.2.3 より 添付ファイル参照方法に変更が加わりました。


### PR DESCRIPTION
添付ファイルのサイズ制限について、リバースプロキシに Nginx を利用している場合の注意事項を追記しました。

なお、Apache の [LimitRequestBody](https://httpd.apache.org/docs/current/ja/mod/core.html#limitrequestbody) はデフォルトが無制限のため、追記しませんでした。

## 関連チケット

- [1M以上のサイズのファイルを添付できない · Issue #3311 · weseek/growi](https://github.com/weseek/growi/issues/3311)