### PR TITLE
ref: #155662 Embed youtube videos

### DIFF
--- a/docs/ja/admin-guide/management-cookbook/plugins.md
+++ b/docs/ja/admin-guide/management-cookbook/plugins.md
@@ -1,13 +1,16 @@
 # プラグイン
 
-::: tip
-このページの内容は、[動画](https://youtu.be/jwfhZ-QgsBA) でも解説しています。
-:::
-
 プラグインをインストールすることで GROWI をカスタマイズできます。
 公開されているプラグインは [GROWI プラグインサイト](https://growi.org/plugins)をご確認ください。
 
 [[toc]]
+
+このページの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】プラグインの適用・活用</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/jwfhZ-QgsBA?si=1D0QPvyHdrH1l0ni" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 ## プラグインのインストール方法
 

--- a/docs/ja/cloud/growiapp.md
+++ b/docs/ja/cloud/growiapp.md
@@ -47,6 +47,9 @@ GROWI へアカウント登録した情報、ページ内容・GCP へアップ�
 
 ## 複数アプリの運用イメージ
 
-::: tip
-このセクションの内容は、[動画](https://youtu.be/kUFSWArpvM0) で解説しています。
-:::
+このセクションの内容は、動画で解説しています。
+
+<figure>
+  <figcaption>【GROWI.cloud】複数アプリの運用イメージ</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/kUFSWArpvM0?si=wgjOZo9CcCAqRJDK" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>

--- a/docs/ja/guide/features/authority.md
+++ b/docs/ja/guide/features/authority.md
@@ -1,10 +1,13 @@
 # ページの閲覧/編集権限を設定する
 
-::: tip
-このページの内容は、[動画](https://youtu.be/q_tXF3RVLyM) でも解説しています。
-:::
-
 GROWI は、ページごとに閲覧/編集権限を設定できます。新しく作成したページには、自動的に親ページの権限が設定されます。
+
+このページの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】ページの閲覧制限の設定</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/q_tXF3RVLyM?si=u07QJzOr5ty95LUf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 ## 設定方法
 

--- a/docs/ja/guide/features/create_page.md
+++ b/docs/ja/guide/features/create_page.md
@@ -1,10 +1,17 @@
 # ページを作成する
 
-::: tip
-このページの内容は、[動画](https://youtu.be/WT_f-CuUADA) でも解説しています。
 
-ページの階層関係については、[こちらの動画](https://youtu.be/tI_QrqOXWDE) で解説しています。
-:::
+このページの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】ページの作成方法</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/WT_f-CuUADA?si=1D0QPvyHdrH1l0ni" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
+
+<figure>
+  <figcaption>【GROWI v7】ページの階層関係</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/tI_QrqOXWDE?si=01Ds7JgC4wNVRxYZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 ## 新しいページを作成する
 

--- a/docs/ja/guide/features/insert_files.md
+++ b/docs/ja/guide/features/insert_files.md
@@ -2,9 +2,12 @@
 
 ## 自分のデバイス上の画像やファイルを挿入する
 
-::: tip
-このセクションの内容は、[動画](https://youtu.be/MfIpdI_4_TI) でも解説しています。
-:::
+このセクションの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】添付ファイルの挿入</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/MfIpdI_4_TI?si=D-ZKnfcrh-mRJYPi" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 以下の3種類の方法で、画像やファイルを挿入できます。
 
@@ -41,9 +44,12 @@ Web 上の画像を挿入するには、以下のように記述します。
 
 ## 動画を挿入する
 
-::: tip
-このセクションの内容は、[動画](https://youtu.be/acFPZu6geUU) でも解説しています。
-:::
+このセクションの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】動画のストリーミング再生</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/acFPZu6geUU?si=fvWiS9VwCnT6DCOM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 ### GROWI にアップロードした動画を埋め込む
 

--- a/docs/ja/guide/features/page_layout.md
+++ b/docs/ja/guide/features/page_layout.md
@@ -51,9 +51,15 @@ GROWI のページレイアウトを紹介します。
 - 添付データの表示
 - 共有リンク管理
   - 非公開の特定のページを外部に公開するためのリンクを管理できます
-  - 共有リンク管理については、[動画](https://youtu.be/vIYRq4vPLow) でも解説しています
 - テンプレートページの作成/編集
 - [ページの削除](/ja/guide/features/page_operation.html)
+
+共有リンク管理については、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】共有リンクの発行・管理</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/vIYRq4vPLow?si=_1vR2HYW14JcPPjT" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 ## 7. ページツールバー
 

--- a/docs/ja/guide/features/search.md
+++ b/docs/ja/guide/features/search.md
@@ -1,8 +1,11 @@
 # ページを検索する
 
-::: tip
-このページの内容は、[動画](https://youtu.be/GwlcwMJlkGg) でも解説しています。
-:::
+このページの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】ページの検索方法</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/GwlcwMJlkGg?si=2EaCbI5JS-dlnCVr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 <ContextualBlock context="docs-growi-org">
 

--- a/docs/ja/guide/features/template.md
+++ b/docs/ja/guide/features/template.md
@@ -6,11 +6,14 @@ GROWI ではテンプレートを利用したページを作ることができ�
 
 ## 階層に対してテンプレートを適用する方法
 
-::: tip
-このセクションの内容は、[動画](https://youtu.be/FpTFmQ2pOgA) でも解説しています。
-:::
-
 ここでは、日報テンプレートを作成する例をご紹介します。
+
+このセクションの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】階層テンプレートの適用方法</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/FpTFmQ2pOgA?si=0g6UABblqRYTrdp4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 ### テンプレートページを作成する
 
@@ -70,9 +73,12 @@ $lsx()
 
 ## ページ単位でテンプレートを挿入する方法
 
-::: tip
-このセクションの内容は、[動画](https://youtu.be/BBiFUI1QLCg) でも解説しています。
-:::
+このセクションの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】ページ単位のテンプレートの適用方法</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/BBiFUI1QLCg?si=t2I6EmjRONd2CFY7" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 GROWIではページ単体でもテンプレートを挿入できます。
 

--- a/docs/ja/guide/getting-started/markdown.md
+++ b/docs/ja/guide/getting-started/markdown.md
@@ -1,10 +1,13 @@
 # Markdown の書き方
 
-::: tip
-このページの内容は、[動画](https://youtu.be/gx5DRVbaiP0) でも解説しています。
-:::
-
 GROWI では Markdown (マークダウン) という書式でページを書くことができます。2、3個の簡単な記法を覚えることで、読みやすい文書を書くことができます。
+
+このページの内容は、動画でも解説しています。
+
+<figure>
+  <figcaption>【GROWI v7】Markdown の活用</figcaption>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/gx5DRVbaiP0?si=abKP1E64VYGPchas" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</figure>
 
 ## 見出しをつける
 


### PR DESCRIPTION
# タスク
https://redmine.weseek.co.jp/issues/155697

# 相談
- 動画にキャプションを付けるために `<figcaption>` を使ったのですが、使わない方がいいとかありますか？
- `<figure>` に適用される style が GROWI Docs と GROWI.cloud ヘルプ で差があり (margin) 見た目が変わるのですが、このタイミングでどうにかしたほうがいいですか？ 

# キャプチャ
![image](https://github.com/user-attachments/assets/a6848d1b-d3cb-4978-a295-10f413745006)

![image](https://github.com/user-attachments/assets/bf88337e-9027-463b-98fa-19d05b0112f7)

