### PR TITLE
Support: ヘルプのリンク切れ修正

### DIFF
--- a/docs/en/admin-guide/management-cookbook/setup-ai.md
+++ b/docs/en/admin-guide/management-cookbook/setup-ai.md
@@ -44,7 +44,7 @@ When the AI function is enabled, the Knowledge Assistant icon appears on the top
 <ContextualBlock context="help-growi-cloud">
 
 - If the AI integration feature does not function correctly despite being enabled:  
-  - Check the [GROWI AI Features](/en/cloud/ai-chat) settings and your [GROWI AI Credit Balance](/en/cloud/ai-credit).  
+  - Check the [GROWI AI Features](/en/cloud/growi-ai-features.html) settings and your [GROWI AI Credit Balance](/en/cloud/growi-ai-credit.html).  
   - If the issue persists after verification, please contact [GROWI.cloud Support](https://growi.cloud/contact).
 
 </ContextualBlock>

--- a/docs/en/admin-guide/management-cookbook/setup-ai.md
+++ b/docs/en/admin-guide/management-cookbook/setup-ai.md
@@ -44,7 +44,7 @@ When the AI function is enabled, the Knowledge Assistant icon appears on the top
 <ContextualBlock context="help-growi-cloud">
 
 - If the AI integration feature does not function correctly despite being enabled:  
-  - Check the [GROWI AI Features](/en/cloud/growi-ai-features.html) settings and your [GROWI AI Credit Balance](/en/cloud/growi-ai-credit.html).  
+  - Check the [GROWI AI 機能(GROWI AI Features japanese page)](/ja/cloud/growi-ai-features.html) settings and your [GROWI AI クレジット(GROWI AI Credit Balance japanese page)](/ja/cloud/growi-ai-credit.html).  
   - If the issue persists after verification, please contact [GROWI.cloud Support](https://growi.cloud/contact).
 
 </ContextualBlock>

--- a/docs/en/guide/features/ai-knowledge-assistant.md
+++ b/docs/en/guide/features/ai-knowledge-assistant.md
@@ -10,7 +10,7 @@
 - The GROWI AI integration feature uploads documents to OpenAI's `Vector Store` for machine learning purposes.  
 - Only public pages are uploaded to OpenAI by GROWI.  
 - When the AI integration feature is enabled, the content and metadata required for machine learning are uploaded to the `Vector Store` whenever a page is created, updated, or duplicated.  
-- To bulk upload already existing pages, perform a "[Rebuild Vector Store](/en/admin-guide/management-cookbook/setup-ai.md#vector-store-rebuild)."
+- To bulk upload already existing pages, perform a "[Rebuild Vector Store](/en/admin-guide/management-cookbook/setup-ai.html#vector-store-rebuild)."
 
 ## How to Use the Knowledge Assistant
 

--- a/docs/ja/admin-guide/management-cookbook/setup-ai.md
+++ b/docs/ja/admin-guide/management-cookbook/setup-ai.md
@@ -44,7 +44,7 @@ AI 機能が有効になっている場合、GROWI 画面のトップバーに�
 <ContextualBlock context="help-growi-cloud">
 
 - 設定を有効にしているにもかかわらず AI 連携機能が正常に利用できない場合
-  - [GROWI AI 機能](/ja/cloud/ai-chat) の設定と [GROWI AI クレジット](/ja/cloud/ai-credit) の残高をご確認ください。
+  - [GROWI AI 機能](/ja/cloud/growi-ai-features.html) の設定と [GROWI AI クレジット](/ja/cloud/growi-ai-credit.html) の残高をご確認ください。
   - 上記をご確認のうえ、問題を解消できない場合は [GROWI.cloud サポートへのお問い合わせ窓口](https://growi.cloud/contact) までお問い合わせください。
 
 </ContextualBlock>

--- a/docs/ja/cloud/growi-ai-features.md
+++ b/docs/ja/cloud/growi-ai-features.md
@@ -53,4 +53,4 @@ GROWI AI 機能を有効にするためには、まず、編集画面に切り�
 ### GROWI の設定を行う
 
 - AI 機能を実際にご利用いただくためには GROWI アプリ上でもセットアップが必要です。
-- 設定方法は、[GROWI AI 機能のセットアップと管理](/ja/admin-guide/management-cookbook/ai-function.html) をご参照ください。
+- 設定方法は、[GROWI AI 機能のセットアップと管理](/ja/admin-guide/management-cookbook/setup-ai.html) をご参照ください。

--- a/docs/ja/guide/features/ai-knowledge-assistant.md
+++ b/docs/ja/guide/features/ai-knowledge-assistant.md
@@ -10,7 +10,7 @@
 - GROWI AI 連携機能では、 OpenAI の `Vector Store` へ文書をアップロードして機械学習の対象とします。
 - GROWI が OpenAI へアップロードするのは、パブリックなページのみです。
 - AI 連携機能が有効な場合、ページの作成・更新・複製のアクションが起こったときに、ページの本文ほか機械学習に必要なメタデータを `Vector Store` へアップロードします。
-- 既に存在するページを一括でアップロードするには、「[Vector Store のリビルド](/ja/admin-guide/management-cookbook/setup-ai.md#vector-store-のリビルド)」を行ってください。
+- 既に存在するページを一括でアップロードするには、「[Vector Store のリビルド](/ja/admin-guide/management-cookbook/setup-ai.html#vector-store-のリビルド)」を行ってください。
 
 ## ナレッジアシスタントの使い方
 


### PR DESCRIPTION
# task
- [#158275: ヘルプのリンク切れ修正](https://redmine.weseek.co.jp/issues/158275)

### やったこと
- リンク修正
  - ページ: AI 連携機能のセットアップと管理
  - リンク:
    - 「GROWI AI 機能」
    - 「GROWI AI クレジット」
  - ページ: (.cloud) GROWI AI 機能
    - 「GROWI AI 機能のセットアップと管理」
  - ナレッジアシスタント
    - 「Vector Store のリビルド」
      - .md となっていたので、 .html に書き換えた
- 英語版も同様だが、一部存在しないファイルがあったので日本語のページへ誘導している箇所あり