### PR TITLE
refs #163657 #163659: [help] sitemap.xml に v2 関係のページとヘルプページが含まれている

### DIFF
--- a/docs/.vuepress/config-help-growi-cloud.js
+++ b/docs/.vuepress/config-help-growi-cloud.js
@@ -426,6 +426,12 @@ module.exports = {
     ['@vuepress/html-redirect', {
       countdown: 0
     }],
+    [
+      'sitemap',
+      {
+        hostname: 'https://growi.cloud/help',
+      },
+    ],
   ],
 
   markdown: {


### PR DESCRIPTION
- https://growi.cloud/help/sitemap.xml がビルド時に出力されるようにした